### PR TITLE
Tweak colors and font weights to match the mocks and expose `showInput` props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raydial-tailwind-datepicker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A modern Datepicker for the Raydial component library using Tailwind CSS 3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/pages/index.js
+++ b/pages/index.js
@@ -53,6 +53,7 @@ export default function Playground() {
           primaryColor={primaryColor}
           onChange={handleChange}
           useRange={useRange}
+          showInput
           showFooter={showFooter}
           showShortcuts={showShortcuts}
           configs={{

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -60,13 +60,13 @@ const Days: React.FC<Props> = ({
       let className = "";
 
       if (dayjs(fullDay).isSame(period.start) && dayjs(fullDay).isSame(period.end)) {
-        className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium rounded-xl`;
+        className = ` ${BG_COLOR["500"][primaryColor]} bg-primary-light text-white rounded-xl`;
       } else if (dayjs(fullDay).isSame(period.start)) {
-        className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium ${
+        className = ` ${BG_COLOR["500"][primaryColor]} text-white ${
           dayjs(fullDay).isSame(dayHover) && !period.end ? "rounded-xl" : "rounded-xl"
         }`;
       } else if (dayjs(fullDay).isSame(period.end)) {
-        className = ` ${BG_COLOR["500"][primaryColor]} text-white font-medium ${
+        className = ` ${BG_COLOR["500"][primaryColor]} text-white ${
           dayjs(fullDay).isSame(dayHover) && !period.start ? "rounded-xl" : "rounded-xl"
         }`;
       }
@@ -90,7 +90,7 @@ const Days: React.FC<Props> = ({
         if (dayjs(fullDay).isBetween(period.start, period.end, "day", "[)")) {
           return ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
             day
-          )} bg-sky-100 dark:bg-white/10`;
+          )} bg-primary-light dark:bg-white/10`;
         }
       }
 
@@ -101,13 +101,13 @@ const Days: React.FC<Props> = ({
       if (period.start && dayjs(fullDay).isBetween(period.start, dayHover, "day", "[)")) {
         className = ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
           day
-        )} bg-sky-100 dark:bg-white/10`;
+        )} bg-primary-light dark:bg-white/10`;
       }
 
       if (period.end && dayjs(fullDay).isBetween(dayHover, period.end, "day", "[)")) {
         className = ` ${BG_COLOR["100"][primaryColor]} ${currentDateClass(
           day
-        )} bg-sky-100 dark:bg-white/10`;
+        )} bg-primary-light dark:bg-white/10`;
       }
 
       if (dayHover === fullDay) {

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -259,7 +259,7 @@ const Calendar: React.FC<Props> = ({
         )}
 
         <div className="flex flex-1 items-center space-x-1.5 min-h-[30px]">
-          <div className="w-full justify-center flex items-center gap-1 font-semibold">
+          <div className="w-full justify-center flex items-center gap-3 font-semibold">
             <p
               className="cursor-pointer"
               onClick={() => {

--- a/src/components/Datepicker.tsx
+++ b/src/components/Datepicker.tsx
@@ -19,6 +19,7 @@ const Datepicker: React.FC<DatepickerType> = ({
   onChange,
   useRange = true,
   showFooter = false,
+  showInput = true,
   showShortcuts = false,
   configs = undefined,
   asSingle = false,
@@ -246,6 +247,7 @@ const Datepicker: React.FC<DatepickerType> = ({
       changeInputText: (newText: string) => setInputText(newText),
       updateFirstDate: (newDate: dayjs.Dayjs) => firstGotoDate(newDate),
       changeDatepickerValue: onChange,
+      showInput,
       showFooter,
       placeholder,
       separator,
@@ -279,6 +281,7 @@ const Datepicker: React.FC<DatepickerType> = ({
     inputText,
     onChange,
     showFooter,
+    showInput,
     placeholder,
     separator,
     i18n,
@@ -314,7 +317,9 @@ const Datepicker: React.FC<DatepickerType> = ({
   return (
     <DatepickerContext.Provider value={contextValues}>
       <div className={containerClassNameOverload} ref={containerRef}>
-        <Input setContextRef={setInputRef} />
+        <div className="flex items-center gap-3">
+          {showInput && <Input setContextRef={setInputRef} />}
+        </div>
 
         <div
           className="transition-all ease-out duration-300 absolute z-10 mt-[1px] text-sm lg:text-xs 2xl:text-sm translate-y-4 opacity-0 hidden"
@@ -322,7 +327,7 @@ const Datepicker: React.FC<DatepickerType> = ({
         >
           <Arrow ref={arrowRef} />
 
-          <div className="mt-2.5 shadow-sm border border-gray-300 px-1 py-0.5 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-600 rounded-lg">
+          <div className="mt-2.5 shadow-sm border border-gray-300 px-1 py-0.5 bg-white dark:bg-slate-800 dark:text-white dark:border-slate-600 rounded-xl">
             <div className="flex flex-col lg:flex-row py-2">
               {showShortcuts && <Shortcuts />}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,7 @@ export interface DatepickerType {
   onChange: (value: DateValueType, e?: HTMLInputElement | null | undefined) => void;
   useRange?: boolean;
   showFooter?: boolean;
+  showInput?: boolean;
   showShortcuts?: boolean;
   configs?: Configs;
   asSingle?: boolean;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,6 @@ module.exports = {
   darkMode: "media",
   theme: {},
   variants: {},
-  plugins: [require("@tailwindcss/forms"), require("raydiant-tailwind")]
+  plugins: [require("@tailwindcss/forms")],
+  presets: [require("raydiant-tailwind")]
 };


### PR DESCRIPTION
## What does this do
Tweak's colors and font weights to match the mocks and expose `showInput` props

## Why is it important
We want the datepicker to be as close to the mocks as possible. `showInput` will be used to use show or hide the date input field
