### PR TITLE
Clean up css class names to be more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raydial-tailwind-datepicker",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A modern Datepicker for the Raydial component library using Tailwind CSS 3",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -200,7 +200,8 @@ const Days: React.FC<Props> = ({
 
   const buttonClass = useCallback(
     (day: number, type: "current" | "next" | "previous") => {
-      const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10 font-bold calendar-day";
+      const baseClass =
+        "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10 font-bold calendar-day";
       if (type === "current") {
         return cn(
           baseClass,

--- a/src/components/Calendar/Days.tsx
+++ b/src/components/Calendar/Days.tsx
@@ -200,7 +200,7 @@ const Days: React.FC<Props> = ({
 
   const buttonClass = useCallback(
     (day: number, type: "current" | "next" | "previous") => {
-      const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10 font-bold day";
+      const baseClass = "flex items-center justify-center w-12 h-12 lg:w-10 lg:h-10 font-bold calendar-day";
       if (type === "current") {
         return cn(
           baseClass,

--- a/src/components/Calendar/Week.tsx
+++ b/src/components/Calendar/Week.tsx
@@ -35,7 +35,7 @@ const Week: React.FC = () => {
   return (
     <div className="grid grid-cols-7 py-2">
       {DAYS.map(item => (
-        <div key={item} className="tracking-wide text-gray-500 text-center week">
+        <div key={item} className="tracking-wide text-gray-500 text-center calendar-week">
           {ucFirst(
             shortString(
               dayjs(`2022-11-${6 + (item + startDateModifier)}`)

--- a/src/components/Calendar/Years.tsx
+++ b/src/components/Calendar/Years.tsx
@@ -15,7 +15,7 @@ const Years: React.FC<Props> = ({ year, minYear, maxYear, clickYear }) => {
     <div className="w-full grid grid-cols-2 gap-2 mt-2">
       {generateArrayNumber(year, year + 11).map((item, index) => (
         <RoundedButton
-          className="year"
+          className="calendar-year"
           key={index}
           padding="py-3"
           onClick={() => {

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -236,7 +236,7 @@ const Calendar: React.FC<Props> = ({
 
   return (
     <div className="w-full md:w-[297px] md:min-w-[297px] calendar">
-      <div className="flex items-center space-x-1.5 rounded-md px-2 py-1.5 header">
+      <div className="flex items-center space-x-1.5 rounded-md px-2 py-1.5 calendar-header">
         {!showMonths && !showYears && (
           <div className="flex-none">
             <RoundedButton roundedFull={true} onClick={onClickPrevious}>
@@ -261,7 +261,7 @@ const Calendar: React.FC<Props> = ({
         <div className="flex flex-1 items-center space-x-1.5 min-h-[30px] label">
           <div className="w-full justify-center flex items-center gap-3 font-semibold">
             <p
-              className="cursor-pointer month"
+              className="cursor-pointer calendar-month"
               onClick={() => {
                 setShowMonths(!showMonths);
                 hideYears();
@@ -270,7 +270,7 @@ const Calendar: React.FC<Props> = ({
               {calendarData.date.locale(i18n).format("MMMM")}
             </p>
             <p
-              className="cursor-pointer year"
+              className="cursor-pointer calendar-year"
               onClick={() => {
                 setShowYears(!showYears);
                 hideMonths();


### PR DESCRIPTION
## What does this do
Clean up css class names to be more explicit

## Why is it important
The class names were clashing with other classes in the raydiant-tailwind-component
